### PR TITLE
Add support for backing IniCfg with multiple concrete .ini files on disk.

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -18,7 +18,7 @@ import (
     "time"
 )
 
-var stopTest = make(chan bool, 0)
+var stopTest = make(chan bool, 1)
 
 
 func TestIni(t *testing.T) {
@@ -29,17 +29,49 @@ func TestIni(t *testing.T) {
         t.Error("expected test, got " + cfg.Name)
     }
 
-    if cfg.Path != "./test.ini" {
-        t.Error("expected ./test.ini, got " + cfg.Path)
+    if len(cfg.Paths) != 1 {
+        t.Errorf("expected cfg.Paths to have 1 entry, got %d", len(cfg.Paths))
+    }
+
+    if cfg.Paths[0] != "./test.ini" {
+        t.Error("expected ./test.ini, got " + cfg.Paths[0])
     }
 
     t.Log(cfg)
 }
 
+func TestMultiFileIni(t *testing.T) {
+    cfg := newIniCfgFromFiles([]string{"./test.ini", "./test2.ini"})
+    
+    if cfg.Name != "test" {
+        t.Error("expected test, got " + cfg.Name)
+    }
+
+	sec := cfg.GetSection("section_1")
+	if sec == VoidSection {
+		t.Errorf("Expected a valid section (from the base file).")
+	}
+
+	// This value comes from the main ini.
+	if sec.GetFirstVal("key1").GetValStr(0, "") != "value1" {
+		t.Errorf("Expected key1 to have value1 (from the base file).")
+	}
+
+	// This value comes from the secondary ini.
+	if sec.GetFirstVal("key3").GetValStr(0, "") != "value3" {
+		t.Errorf("Expected key3 to have value3 (from the merged file).")
+	}
+
+	// This section comes from the secondary ini.
+	if cfg.GetSection("section3") == VoidSection {
+		t.Errorf("Expected a valid section (from the merged file).")
+	}
+}
+
 func TestIniMonitor(t *testing.T) {
     cfg := New("./test.ini")
     Subscribe(cfg, onCfgChange)
-    err := touch(cfg.Path)
+    err := touch(cfg.Paths[0])
     if err != nil {
         t.Fatal(err)
     }

--- a/test2.ini
+++ b/test2.ini
@@ -1,0 +1,6 @@
+[section3]
+morestuff=yay
+key1=morevalues
+
+[section 1]
+key3=value3


### PR DESCRIPTION
This change allows IniCfg objects to be loaded from multiple actual .ini files.

The first .ini file provided is used for the IniCfg's name. Subsequent .ini files are parsed as if they were concatenated to the initial file, with all the same behaviors that implies (in terms of appending to keys, et cetera). However, the IniCfg object still understands that it was formed from multiple files and will recognize changes to any source when evaluating whether or not to fire the change callback.